### PR TITLE
Update repo URL

### DIFF
--- a/roles/webui/tasks/main.yml
+++ b/roles/webui/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: checkout webui
   git:
-    repo: git://github.com/clusterinthecloud/webui.git
+    repo: https://github.com/clusterinthecloud/webui.git
     force: yes
     dest: "{{ webui_dir }}"
     version: master


### PR DESCRIPTION
The use of the git:// protocol is now deprecated and no longer used, therefore it has been changed to https as this more secure and supported.