### PR TITLE
Updating compute.yml

### DIFF
--- a/compute.yml
+++ b/compute.yml
@@ -1,15 +1,14 @@
 ---
 
 - hosts: compute
+  vars:
+    ansible_python_interpreter: /usr/libexec/platform-python
   become: yes
   tasks:
     - name: disable SELinux
       selinux:
         state: permissive
         policy: targeted
-
-- hosts: compute
-  become: yes
   roles:
     - citc_user
     - filesystem


### PR DESCRIPTION
Due to the ansible update in epel, it no longer uses the platform-python by default which means it uses python3.8, however the SELINUX modules are in python3.6 this fixes the issue and allows for the playbook to run.